### PR TITLE
Add 'WebhookTemplate' 

### DIFF
--- a/src/Samples/Echo/Echo.csproj
+++ b/src/Samples/Echo/Echo.csproj
@@ -79,9 +79,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="application.json">
+    <Content Include="application.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
 using Takenet.MessagingHub.Client.Host;
+using Takenet.MessagingHub.Client.Sender;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -10,8 +14,30 @@ namespace Takenet.MessagingHub.Client.WebHost
         public static async Task StartAsync()
         {
             var applicationFileName = Bootstrapper.DefaultApplicationFileName;
-            var application = Application.ParseFromJsonFile(applicationFileName);
-            var stopabble = await Bootstrapper.StartAsync(application);
+            var application = Application.ParseFromJsonFile(Path.Combine(GetAssemblyRoot(), applicationFileName));
+
+            var localServiceProvider = Bootstrapper.BuildServiceProvider(application);
+
+            localServiceProvider.RegisterService(typeof(IServiceProvider), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(IServiceContainer), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(Application), application);
+            Bootstrapper.RegisterSettingsContainer(application, localServiceProvider);
+
+            var envelopeBuffer = new EnvelopeBuffer();
+            localServiceProvider.RegisterService(typeof(IEnvelopeBuffer), envelopeBuffer);
+            var client = await Bootstrapper.BuildMessagingHubClientAsync(application, () => new MessagingHubClient(new HttpMessagingHubConnection(envelopeBuffer)), localServiceProvider);
+
+            await client.StartAsync().ConfigureAwait(false);
+
+            await Bootstrapper.BuildStartupAsync(application, localServiceProvider);
+        }
+
+        private static string GetAssemblyRoot()
+        {
+            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            var path = Uri.UnescapeDataString(uri.Path);
+            return Path.GetDirectoryName(path);
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
@@ -22,7 +22,7 @@ namespace Takenet.MessagingHub.Client.WebHost
 
             var envelopeBuffer = new EnvelopeBuffer();
             localServiceProvider.RegisterService(typeof(IEnvelopeBuffer), envelopeBuffer);
-            var client = await Bootstrapper.BuildMessagingHubClientAsync(application, () => new MessagingHubClient(new HttpMessagingHubConnection(envelopeBuffer)), localServiceProvider);
+            var client = await Bootstrapper.BuildMessagingHubClientAsync(application, () => new MessagingHubClient(new HttpMessagingHubConnection(envelopeBuffer, application)), localServiceProvider);
 
             await client.StartAsync().ConfigureAwait(false);
 

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Web;
+using Takenet.MessagingHub.Client.Host;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public static class MessagingHubConfig
+    {
+        public static async Task StartAsync()
+        {
+            var applicationFileName = Bootstrapper.DefaultApplicationFileName;
+            var application = Application.ParseFromJsonFile(applicationFileName);
+            var stopabble = await Bootstrapper.StartAsync(application);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/MessagingHubConfig.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Web;
 using Takenet.MessagingHub.Client.Host;
-using Takenet.MessagingHub.Client.Sender;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
     public static class MessagingHubConfig
     {
-        public static async Task StartAsync()
+        public static async Task<IServiceContainer> StartAsync()
         {
             var applicationFileName = Bootstrapper.DefaultApplicationFileName;
             var application = Application.ParseFromJsonFile(Path.Combine(GetAssemblyRoot(), applicationFileName));
@@ -30,6 +27,8 @@ namespace Takenet.MessagingHub.Client.WebHost
             await client.StartAsync().ConfigureAwait(false);
 
             await Bootstrapper.BuildStartupAsync(application, localServiceProvider);
+
+            return localServiceProvider;
         }
 
         private static string GetAssemblyRoot()

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using Lime.Protocol;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using Takenet.MessagingHub.Client.WebHost.Models;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -11,6 +13,9 @@ namespace Takenet.MessagingHub.Client.WebHost
         {
             // Web API routes
             config.MapHttpAttributeRoutes();
+
+            config.BindParameter(typeof(Message), new EnvelopeModelBinder());
+            config.BindParameter(typeof(Notification), new EnvelopeModelBinder());
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/App_Start/WebApiConfig.cs
@@ -9,16 +9,8 @@ namespace Takenet.MessagingHub.Client.WebHost
     {
         public static void Register(HttpConfiguration config)
         {
-            // Web API configuration and services
-
             // Web API routes
             config.MapHttpAttributeRoutes();
-
-            config.Routes.MapHttpRoute(
-                name: "DefaultApi",
-                routeTemplate: "api/{controller}/{id}",
-                defaults: new { id = RouteParameter.Optional }
-            );
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/Controllers/EnvelopeController.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Controllers/EnvelopeController.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using System.Web.Http;
+
+namespace Takenet.MessagingHub.Client.WebHost.Controllers
+{
+    public class EnvelopeController : ApiController
+    {
+        private readonly IEnvelopeBuffer _envelopeBuffer;
+
+        public EnvelopeController(IEnvelopeBuffer envelopeBuffer)
+        {
+            _envelopeBuffer = envelopeBuffer;
+        }
+
+        [Route("messages")]
+        public Task Post(Lime.Protocol.Message message)
+        {
+            return _envelopeBuffer.Messages.SendAsync(message);
+        }
+
+        [Route("notifications")]
+        public Task Post(Lime.Protocol.Notification notification)
+        {
+            return _envelopeBuffer.Notifications.SendAsync(notification);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/Controllers/EnvelopeController.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Controllers/EnvelopeController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using System.Web.Http;
+using Takenet.MessagingHub.Client.WebHost.Models;
 
 namespace Takenet.MessagingHub.Client.WebHost.Controllers
 {

--- a/src/Takenet.MessagingHub.Client.WebHost/EnvelopeBuffer.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/EnvelopeBuffer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks.Dataflow;
+using Lime.Protocol;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public class EnvelopeBuffer : IEnvelopeBuffer
+    {
+        public EnvelopeBuffer()
+        {
+            var options = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded
+            };
+            Commands = new BufferBlock<Command>(options);
+            Messages = new BufferBlock<Message>(options);
+            Notifications = new BufferBlock<Notification>(options);
+        }
+
+        public BufferBlock<Command> Commands { get; }
+
+        public BufferBlock<Message> Messages { get; }
+
+        public BufferBlock<Notification> Notifications { get; }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/Global.asax
+++ b/src/Takenet.MessagingHub.Client.WebHost/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="Takenet.MessagingHub.Client.WebHost.WebApiApplication" Language="C#" %>

--- a/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.Http;
 using System.Web.Routing;
+using Takenet.MessagingHub.Client.WebHost.Controllers;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -12,7 +13,12 @@ namespace Takenet.MessagingHub.Client.WebHost
         protected void Application_Start()
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
-            MessagingHubConfig.StartAsync().Wait();
+
+            var serviceContainer = MessagingHubConfig.StartAsync().Result;
+            serviceContainer.RegisterService(
+                typeof(EnvelopeController), 
+                () => new EnvelopeController(serviceContainer.GetService(typeof(IEnvelopeBuffer)) as IEnvelopeBuffer));
+            GlobalConfiguration.Configuration.DependencyResolver = new MessagingHubClientResolver(serviceContainer);
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Routing;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Global.asax.cs
@@ -12,6 +12,7 @@ namespace Takenet.MessagingHub.Client.WebHost
         protected void Application_Start()
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
+            MessagingHubConfig.StartAsync().Wait();
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Lime.Protocol.Client;
+using Takenet.MessagingHub.Client.Connection;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public class HttpMessagingHubConnection : IMessagingHubConnection
+    {
+        public bool IsConnected { get; private set; }
+
+        public TimeSpan SendTimeout { get; }
+
+        public int MaxConnectionRetries { get; set; }
+
+        public IOnDemandClientChannel OnDemandClientChannel { get; }
+
+        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer)
+        {
+            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer);
+        }
+
+        public Task ConnectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            IsConnected = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            IsConnected = false;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
@@ -7,6 +7,7 @@ using System.Web;
 using Lime.Protocol.Client;
 using Takenet.MessagingHub.Client.Connection;
 using Takenet.MessagingHub.Client.Host;
+using Lime.Protocol.Serialization;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -20,9 +21,9 @@ namespace Takenet.MessagingHub.Client.WebHost
 
         public IOnDemandClientChannel OnDemandClientChannel { get; }
 
-        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer, Application applicationSettings)
+        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer, IEnvelopeSerializer serializer, Application applicationSettings)
         {
-            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer, applicationSettings);
+            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer, serializer, applicationSettings);
         }
 
         public Task ConnectAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
@@ -15,7 +15,7 @@ namespace Takenet.MessagingHub.Client.WebHost
     {
         public bool IsConnected { get; private set; }
 
-        public TimeSpan SendTimeout { get; }
+        public TimeSpan SendTimeout { get; private set; }
 
         public int MaxConnectionRetries { get; set; }
 
@@ -24,6 +24,7 @@ namespace Takenet.MessagingHub.Client.WebHost
         public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer, IEnvelopeSerializer serializer, Application applicationSettings)
         {
             OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer, serializer, applicationSettings);
+            SendTimeout = TimeSpan.FromMilliseconds(applicationSettings.SendTimeout <= 0 ? 10000 : applicationSettings.SendTimeout);
         }
 
         public Task ConnectAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpMessagingHubConnection.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web;
 using Lime.Protocol.Client;
 using Takenet.MessagingHub.Client.Connection;
+using Takenet.MessagingHub.Client.Host;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -19,9 +20,9 @@ namespace Takenet.MessagingHub.Client.WebHost
 
         public IOnDemandClientChannel OnDemandClientChannel { get; }
 
-        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer)
+        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer, Application applicationSettings)
         {
-            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer);
+            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer, applicationSettings);
         }
 
         public Task ConnectAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
@@ -22,12 +22,15 @@ namespace Takenet.MessagingHub.Client.WebHost
         private readonly string _baseUrl;
         private readonly HttpClient _client;
         private readonly Application _applicationSettings;
+        private readonly string _webhookKey;
 
         public HttpOnDemandClientChannel(IEnvelopeBuffer envelopeBuffer, IEnvelopeSerializer serializer, Application applicationSettings)
         {
             _baseUrl = ConfigurationManager.AppSettings["MessagingHub.BaseUrl"];
+            _webhookKey = ConfigurationManager.AppSettings["MessagingHub.WebhookKey"];
             _client = new HttpClient();
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Key", GetAuthCredentials(applicationSettings));
+            _client.DefaultRequestHeaders.Authorization = 
+                new AuthenticationHeaderValue("Key", _webhookKey ?? GetAuthCredentials(applicationSettings));
             _envelopeBuffer = envelopeBuffer;
             _applicationSettings = applicationSettings;
             _serializer = serializer;

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
@@ -8,6 +8,8 @@ using Lime.Protocol.Network;
 using System.Configuration;
 using System.Net.Http;
 using System.Threading.Tasks.Dataflow;
+using Takenet.MessagingHub.Client.Host;
+using System.Net.Http.Headers;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
@@ -16,12 +18,15 @@ namespace Takenet.MessagingHub.Client.WebHost
         private readonly IEnvelopeBuffer _envelopeBuffer;
         private readonly string _baseUrl;
         private readonly HttpClient _client;
+        private readonly Application _applicationSettings;
 
-        public HttpOnDemandClientChannel(IEnvelopeBuffer envelopeBuffer)
+        public HttpOnDemandClientChannel(IEnvelopeBuffer envelopeBuffer, Application applicationSettings)
         {
             _baseUrl = ConfigurationManager.AppSettings["MessagingHub.BaseUrl"];
             _client = new HttpClient();
-           _envelopeBuffer = envelopeBuffer;
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Key", GetAuthCredentials(applicationSettings));
+            _envelopeBuffer = envelopeBuffer;
+            _applicationSettings = applicationSettings;
         }
 
         public ICollection<Func<ChannelInformation, Task>> ChannelCreatedHandlers
@@ -114,5 +119,8 @@ namespace Takenet.MessagingHub.Client.WebHost
         {
             _client.Dispose();
         }
+
+        private string GetAuthCredentials(Application applicationSettings) => 
+            $"{applicationSettings.Identifier}:{applicationSettings.AccessKey.FromBase64()}".ToBase64();
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
@@ -92,19 +92,22 @@ namespace Takenet.MessagingHub.Client.WebHost
             return _envelopeBuffer.Notifications.ReceiveAsync(cancellationToken);
         }
 
-        public Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+        public async Task SendCommandAsync(Command command, CancellationToken cancellationToken)
         {
-            return _client.PostAsJsonAsync($"{_baseUrl}/commands", command, cancellationToken);
+            var response = await _client.PostAsJsonAsync($"{_baseUrl}/commands", command, cancellationToken);
+            response.EnsureSuccessStatusCode();
         }
 
-        public Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+        public async Task SendMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            return _client.PostAsJsonAsync($"{_baseUrl}/messages", message, cancellationToken);
+            var response = await _client.PostAsJsonAsync($"{_baseUrl}/messages", message, cancellationToken);
+            response.EnsureSuccessStatusCode();
         }
 
-        public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+        public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
         {
-            return _client.PostAsJsonAsync($"{_baseUrl}/notifications", notification, cancellationToken);
+            var response = await _client.PostAsJsonAsync($"{_baseUrl}/notifications", notification, cancellationToken);
+            response.EnsureSuccessStatusCode();
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Lime.Protocol;
+using Lime.Protocol.Client;
+using Lime.Protocol.Network;
+using System.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks.Dataflow;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    internal class HttpOnDemandClientChannel : IOnDemandClientChannel
+    {
+        private readonly IEnvelopeBuffer _envelopeBuffer;
+        private readonly string _baseUrl;
+        private readonly HttpClient _client;
+
+        public HttpOnDemandClientChannel(IEnvelopeBuffer envelopeBuffer)
+        {
+            _baseUrl = ConfigurationManager.AppSettings["MessagingHub.BaseUrl"];
+            _client = new HttpClient();
+           _envelopeBuffer = envelopeBuffer;
+        }
+
+        public ICollection<Func<ChannelInformation, Task>> ChannelCreatedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<FailedChannelInformation, Task<bool>>> ChannelCreationFailedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<ChannelInformation, Task>> ChannelDiscardedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<FailedChannelInformation, Task<bool>>> ChannelOperationFailedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IsEstablished { get; private set; }
+
+        public Task EstablishAsync(CancellationToken cancellationToken)
+        {
+            IsEstablished = true;
+            return Task.CompletedTask;
+        }
+
+        public Task FinishAsync(CancellationToken cancellationToken)
+        {
+            IsEstablished = false;
+            return Task.CompletedTask;
+        }
+
+        public async Task<Command> ProcessCommandAsync(Command requestCommand, CancellationToken cancellationToken)
+        {
+            var response = await _client.PostAsJsonAsync($"{_baseUrl}/commands", requestCommand, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsAsync<Command>(cancellationToken);
+        }
+
+        public Task<Command> ReceiveCommandAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Commands.ReceiveAsync(cancellationToken);
+        }
+
+        public Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Messages.ReceiveAsync(cancellationToken);
+        }
+
+        public Task<Notification> ReceiveNotificationAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Notifications.ReceiveAsync(cancellationToken);
+        }
+
+        public Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+        {
+            return _client.PostAsJsonAsync($"{_baseUrl}/commands", command, cancellationToken);
+        }
+
+        public Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+        {
+            return _client.PostAsJsonAsync($"{_baseUrl}/messages", message, cancellationToken);
+        }
+
+        public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+        {
+            return _client.PostAsJsonAsync($"{_baseUrl}/notifications", notification, cancellationToken);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/HttpOnDemandClientChannel.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks.Dataflow;
 
 namespace Takenet.MessagingHub.Client.WebHost
 {
-    internal class HttpOnDemandClientChannel : IOnDemandClientChannel
+    internal class HttpOnDemandClientChannel : IOnDemandClientChannel, IDisposable
     {
         private readonly IEnvelopeBuffer _envelopeBuffer;
         private readonly string _baseUrl;
@@ -108,6 +108,11 @@ namespace Takenet.MessagingHub.Client.WebHost
         {
             var response = await _client.PostAsJsonAsync($"{_baseUrl}/notifications", notification, cancellationToken);
             response.EnsureSuccessStatusCode();
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
         }
     }
 }

--- a/src/Takenet.MessagingHub.Client.WebHost/IEnvelopeBuffer.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/IEnvelopeBuffer.cs
@@ -1,0 +1,12 @@
+﻿using Lime.Protocol;
+using System.Threading.Tasks.Dataflow;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    public interface IEnvelopeBuffer
+    {
+        BufferBlock<Message> Messages { get; }
+        BufferBlock<Notification> Notifications { get; }
+        BufferBlock<Command> Commands { get; }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/MessagingHubClientResolver.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/MessagingHubClientResolver.cs
@@ -1,0 +1,37 @@
+﻿using Lime.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Dependencies;
+using Takenet.MessagingHub.Client.Host;
+
+namespace Takenet.MessagingHub.Client.WebHost
+{
+    internal class MessagingHubClientResolver : IDependencyResolver, IDependencyScope
+    {
+        private IServiceContainer _serviceContainer;
+
+        public MessagingHubClientResolver(IServiceContainer serviceContainer)
+        {
+            _serviceContainer = serviceContainer;
+        }
+
+        public IDependencyScope BeginScope()
+        {
+            return this as IDependencyScope;
+        }
+
+        public void Dispose()
+        {
+            _serviceContainer.DisposeIfDisposable();
+        }
+
+        public object GetService(Type serviceType) => _serviceContainer.GetService(serviceType);
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            var services = _serviceContainer.GetService(serviceType);
+            return services as IEnumerable<object> ?? Enumerable.Empty<object>();
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/Models/EnvelopeModelBinder.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Models/EnvelopeModelBinder.cs
@@ -1,0 +1,25 @@
+﻿using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
+using System;
+using System.Web.Http.Controllers;
+using System.Web.Http.ModelBinding;
+
+namespace Takenet.MessagingHub.Client.WebHost.Models
+{
+    public class EnvelopeModelBinder : IModelBinder
+    {
+        private readonly JsonNetSerializer _serializer;
+
+        public EnvelopeModelBinder()
+        {
+            _serializer = new JsonNetSerializer();
+        }
+
+        public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)
+        {
+            var json = actionContext.Request.Content.ReadAsStringAsync().Result;
+            bindingContext.Model = _serializer.Deserialize(json);
+            return bindingContext.Model != null;        
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebHost/Properties/AssemblyInfo.cs
+++ b/src/Takenet.MessagingHub.Client.WebHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Takenet.MessagingHub.Client.WebHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Takenet.MessagingHub.Client.WebHost")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5ed33bde-a2ba-480b-b487-c5c896da726e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
+++ b/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
@@ -120,6 +120,10 @@
     <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Samples\Echo\Echo.csproj">
+      <Project>{3a9fde75-7089-4591-a57f-8825ec131a1d}</Project>
+      <Name>Echo</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Takenet.MessagingHub.Client\Takenet.MessagingHub.Client.csproj">
       <Project>{628f8ee4-956a-49ce-b9d6-bd5f6800fe6f}</Project>
       <Name>Takenet.MessagingHub.Client</Name>

--- a/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
+++ b/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
@@ -105,6 +105,7 @@
     <Compile Include="HttpOnDemandClientChannel.cs" />
     <Compile Include="IEnvelopeBuffer.cs" />
     <Compile Include="MessagingHubClientResolver.cs" />
+    <Compile Include="Models\EnvelopeModelBinder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -118,7 +119,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
-    <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Samples\Echo\Echo.csproj">

--- a/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
+++ b/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{5ED33BDE-A2BA-480B-B487-C5C896DA726E}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Takenet.MessagingHub.Client.WebHost</RootNamespace>
+    <AssemblyName>Takenet.MessagingHub.Client.WebHost</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Lime.Protocol, Version=0.6.24.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lime.Protocol.0.6.24\lib\net461\Lime.Protocol.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\EnvelopeController.cs" />
+    <Compile Include="EnvelopeBuffer.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="HttpMessagingHubConnection.cs" />
+    <Compile Include="HttpOnDemandClientChannel.cs" />
+    <Compile Include="IEnvelopeBuffer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+    <Folder Include="Models\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Takenet.MessagingHub.Client\Takenet.MessagingHub.Client.csproj">
+      <Project>{628f8ee4-956a-49ce-b9d6-bd5f6800fe6f}</Project>
+      <Name>Takenet.MessagingHub.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>52017</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:52017/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
+++ b/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
@@ -104,6 +104,7 @@
     <Compile Include="HttpMessagingHubConnection.cs" />
     <Compile Include="HttpOnDemandClientChannel.cs" />
     <Compile Include="IEnvelopeBuffer.cs" />
+    <Compile Include="MessagingHubClientResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
+++ b/src/Takenet.MessagingHub.Client.WebHost/Takenet.MessagingHub.Client.WebHost.csproj
@@ -94,6 +94,7 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Start\MessagingHubConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\EnvelopeController.cs" />
     <Compile Include="EnvelopeBuffer.cs" />

--- a/src/Takenet.MessagingHub.Client.WebHost/Web.Debug.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebHost/Web.Release.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebHost/Web.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/Web.config
@@ -5,7 +5,10 @@
   -->
 <configuration>
   <appSettings>
-    <add key="MessagingHub.BaseUrl" value="https://msging.net/bot/"/>
+    <add key="MessagingHub.BaseUrl" value="https://hmg.msging.net/"/>
+    <!--<add key="MessagingHub.Identifier" value="identifier"/>
+    <add key="MessagingHub.AccessKey" value="key"/>-->
+    <add key="MessagingHub.SendTimeout" value="15000"/>
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.6.1" />

--- a/src/Takenet.MessagingHub.Client.WebHost/Web.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/Web.config
@@ -7,7 +7,8 @@
   <appSettings>
     <add key="MessagingHub.BaseUrl" value="https://hmg.msging.net/"/>
     <!--<add key="MessagingHub.Identifier" value="identifier"/>
-    <add key="MessagingHub.AccessKey" value="key"/>-->
+    <add key="MessagingHub.AccessKey" value="key"/>-->    
+    <add key="MessagingHub.WebhookKey" value="dGFrZXFhbWluZWxsaTE2MDkwMjpHTlJzTzVGRzFyaDJPbEF0ek50TQ=="/>
     <add key="MessagingHub.SendTimeout" value="15000"/>
   </appSettings>
   <system.web>

--- a/src/Takenet.MessagingHub.Client.WebHost/Web.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/Web.config
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings>
+    <add key="MessagingHub.BaseUrl" value="https://msging.net/bot/"/>
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.6.1" />
+    <httpRuntime targetFramework="4.6.1" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebHost/packages.config
+++ b/src/Takenet.MessagingHub.Client.WebHost/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Lime.Protocol" version="0.6.24" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/App_Start/MessagingHubConfig.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/App_Start/MessagingHubConfig.cs.pp
@@ -1,0 +1,60 @@
+﻿using Lime.Protocol.Serialization.Newtonsoft;
+using System;
+using System.Configuration;
+using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using Takenet.MessagingHub.Client.Host;
+
+namespace $rootnamespace$
+{
+    public static class MessagingHubConfig
+    {
+        public static async Task<IServiceContainer> StartAsync()
+        {
+            var applicationFileName = Bootstrapper.DefaultApplicationFileName;
+            var application = Application.ParseFromJsonFile(Path.Combine(GetAssemblyRoot(), applicationFileName));
+            ApplyConfigurationOverrides(application);
+
+            var localServiceProvider = Bootstrapper.BuildServiceProvider(application);
+
+            localServiceProvider.RegisterService(typeof(IServiceProvider), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(IServiceContainer), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(Application), application);
+            Bootstrapper.RegisterSettingsContainer(application, localServiceProvider);
+
+            var envelopeBuffer = new EnvelopeBuffer();
+            localServiceProvider.RegisterService(typeof(IEnvelopeBuffer), envelopeBuffer);
+            var client = await Bootstrapper.BuildMessagingHubClientAsync(application, () => new MessagingHubClient(new HttpMessagingHubConnection(envelopeBuffer, new JsonNetSerializer(), application)), localServiceProvider);
+
+            await client.StartAsync().ConfigureAwait(false);
+
+            await Bootstrapper.BuildStartupAsync(application, localServiceProvider);
+
+            return localServiceProvider;
+        }
+
+        private static void ApplyConfigurationOverrides(Application application)
+        {
+            application.Identifier = GetOverride(() => application.Identifier);
+            application.AccessKey = GetOverride(() => application.AccessKey);
+        }
+
+        private static string GetOverride(Expression<Func<string>> propertyLambda)
+        {
+            var memberExpression = propertyLambda.Body as MemberExpression;
+
+            if (memberExpression == null) return propertyLambda.Compile().Invoke();
+            return ConfigurationManager.AppSettings[$"MessagingHub.{memberExpression.Member.Name}"] ?? propertyLambda.Compile().Invoke();
+        }
+
+        private static string GetAssemblyRoot()
+        {
+            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            var path = Uri.UnescapeDataString(uri.Path);
+            return Path.GetDirectoryName(path);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/App_Start/WebApiConfig.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/App_Start/WebApiConfig.cs.pp
@@ -1,0 +1,21 @@
+﻿using Lime.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using Takenet.MessagingHub.Client.WebHost.Models;
+
+namespace $rootnamespace$
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.BindParameter(typeof(Message), new EnvelopeModelBinder());
+            config.BindParameter(typeof(Notification), new EnvelopeModelBinder());
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Controllers/EnvelopeController.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Controllers/EnvelopeController.cs.pp
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using System.Web.Http;
+using Takenet.MessagingHub.Client.WebHost.Models;
+
+namespace $rootnamespace$
+{
+    public class EnvelopeController : ApiController
+    {
+        private readonly IEnvelopeBuffer _envelopeBuffer;
+
+        public EnvelopeController(IEnvelopeBuffer envelopeBuffer)
+        {
+            _envelopeBuffer = envelopeBuffer;
+        }
+
+        [Route("messages")]
+        public Task Post(Lime.Protocol.Message message)
+        {
+            return _envelopeBuffer.Messages.SendAsync(message);
+        }
+
+        [Route("notifications")]
+        public Task Post(Lime.Protocol.Notification notification)
+        {
+            return _envelopeBuffer.Notifications.SendAsync(notification);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/EnvelopeBuffer.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/EnvelopeBuffer.cs.pp
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks.Dataflow;
+using Lime.Protocol;
+
+namespace $rootnamespace$
+{
+    public class EnvelopeBuffer : IEnvelopeBuffer
+    {
+        public EnvelopeBuffer()
+        {
+            var options = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded
+            };
+            Commands = new BufferBlock<Command>(options);
+            Messages = new BufferBlock<Message>(options);
+            Notifications = new BufferBlock<Notification>(options);
+        }
+
+        public BufferBlock<Command> Commands { get; }
+
+        public BufferBlock<Message> Messages { get; }
+
+        public BufferBlock<Notification> Notifications { get; }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Global.asax.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Global.asax.cs.pp
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Routing;
+using Takenet.MessagingHub.Client.WebHost.Controllers;
+
+namespace $rootnamespace$
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+
+            var serviceContainer = MessagingHubConfig.StartAsync().Result;
+            serviceContainer.RegisterService(
+                typeof(EnvelopeController), 
+                () => new EnvelopeController(serviceContainer.GetService(typeof(IEnvelopeBuffer)) as IEnvelopeBuffer));
+            GlobalConfiguration.Configuration.DependencyResolver = new MessagingHubClientResolver(serviceContainer);
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Global.asax.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Global.asax.pp
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="$rootnamespace$.WebApiApplication" Language="C#" %>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/HttpMessagingHubConnection.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/HttpMessagingHubConnection.cs.pp
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Lime.Protocol.Client;
+using Takenet.MessagingHub.Client.Connection;
+using Takenet.MessagingHub.Client.Host;
+using Lime.Protocol.Serialization;
+
+namespace $rootnamespace$
+{
+    public class HttpMessagingHubConnection : IMessagingHubConnection
+    {
+        public bool IsConnected { get; private set; }
+
+        public TimeSpan SendTimeout { get; private set; }
+
+        public int MaxConnectionRetries { get; set; }
+
+        public IOnDemandClientChannel OnDemandClientChannel { get; }
+
+        public HttpMessagingHubConnection(IEnvelopeBuffer envelopeBuffer, IEnvelopeSerializer serializer, Application applicationSettings)
+        {
+            OnDemandClientChannel = new HttpOnDemandClientChannel(envelopeBuffer, serializer, applicationSettings);
+            SendTimeout = TimeSpan.FromMilliseconds(applicationSettings.SendTimeout <= 0 ? 10000 : applicationSettings.SendTimeout);
+        }
+
+        public Task ConnectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            IsConnected = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            IsConnected = false;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/HttpOnDemandClientChannel.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/HttpOnDemandClientChannel.cs.pp
@@ -1,0 +1,147 @@
+﻿using Lime.Protocol;
+using Lime.Protocol.Client;
+using Lime.Protocol.Network;
+using Lime.Protocol.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Takenet.MessagingHub.Client.Host;
+
+namespace $rootnamespace$
+{
+    internal class HttpOnDemandClientChannel : IOnDemandClientChannel, IDisposable
+    {
+        private readonly IEnvelopeSerializer _serializer;
+        private readonly IEnvelopeBuffer _envelopeBuffer;
+        private readonly string _baseUrl;
+        private readonly HttpClient _client;
+        private readonly Application _applicationSettings;
+        private readonly string _webhookKey;
+
+        public HttpOnDemandClientChannel(IEnvelopeBuffer envelopeBuffer, IEnvelopeSerializer serializer, Application applicationSettings)
+        {
+            _baseUrl = ConfigurationManager.AppSettings["MessagingHub.BaseUrl"];
+            _webhookKey = ConfigurationManager.AppSettings["MessagingHub.WebhookKey"];
+            _client = new HttpClient();
+            _client.DefaultRequestHeaders.Authorization = 
+                new AuthenticationHeaderValue("Key", _webhookKey ?? GetAuthCredentials(applicationSettings));
+            _envelopeBuffer = envelopeBuffer;
+            _applicationSettings = applicationSettings;
+            _serializer = serializer;
+        }
+
+        public ICollection<Func<ChannelInformation, Task>> ChannelCreatedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<FailedChannelInformation, Task<bool>>> ChannelCreationFailedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<ChannelInformation, Task>> ChannelDiscardedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<Func<FailedChannelInformation, Task<bool>>> ChannelOperationFailedHandlers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IsEstablished { get; private set; }
+
+        public Task EstablishAsync(CancellationToken cancellationToken)
+        {
+            IsEstablished = true;
+            return Task.CompletedTask;
+        }
+
+        public Task FinishAsync(CancellationToken cancellationToken)
+        {
+            IsEstablished = false;
+            return Task.CompletedTask;
+        }
+
+        public async Task<Command> ProcessCommandAsync(Command requestCommand, CancellationToken cancellationToken)
+        {
+            var response = await _client.PostAsJsonAsync($"{_baseUrl}/commands", requestCommand, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsAsync<Command>(cancellationToken);
+        }
+
+        public Task<Command> ReceiveCommandAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Commands.ReceiveAsync(cancellationToken);
+        }
+
+        public Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Messages.ReceiveAsync(cancellationToken);
+        }
+
+        public Task<Notification> ReceiveNotificationAsync(CancellationToken cancellationToken)
+        {
+            return _envelopeBuffer.Notifications.ReceiveAsync(cancellationToken);
+        }
+
+        public async Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+        {
+            using (var content = GetContent(command))
+            using (var response = await _client.PostAsync($"{_baseUrl}commands", content, cancellationToken))
+            {
+                response.EnsureSuccessStatusCode();
+                _envelopeBuffer.Commands.Post(
+                    _serializer.Deserialize((await response.Content.ReadAsStringAsync())) as Command);
+            }
+        }
+
+        public async Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+        {
+            using (var content = GetContent(message))
+            using (var response = await _client.PostAsync($"{_baseUrl}messages", content, cancellationToken))
+            {
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+        {
+            using(var content = GetContent(notification))
+            using (var response = await _client.PostAsync($"{_baseUrl}notifications", content, cancellationToken))
+            {
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+
+        private HttpContent GetContent(Envelope envelope) => 
+            new StringContent(_serializer.Serialize(envelope), Encoding.UTF8, "application/json");
+
+        private string GetAuthCredentials(Application applicationSettings) => 
+            $"{applicationSettings.Identifier}:{applicationSettings.AccessKey.FromBase64()}".ToBase64();
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/IEnvelopeBuffer.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/IEnvelopeBuffer.cs.pp
@@ -1,0 +1,12 @@
+﻿using Lime.Protocol;
+using System.Threading.Tasks.Dataflow;
+
+namespace $rootnamespace$
+{
+    public interface IEnvelopeBuffer
+    {
+        BufferBlock<Message> Messages { get; }
+        BufferBlock<Notification> Notifications { get; }
+        BufferBlock<Command> Commands { get; }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/MessagingHubClientResolver.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/MessagingHubClientResolver.cs.pp
@@ -1,0 +1,37 @@
+﻿using Lime.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Dependencies;
+using Takenet.MessagingHub.Client.Host;
+
+namespace $rootnamespace$
+{
+    internal class MessagingHubClientResolver : IDependencyResolver, IDependencyScope
+    {
+        private IServiceContainer _serviceContainer;
+
+        public MessagingHubClientResolver(IServiceContainer serviceContainer)
+        {
+            _serviceContainer = serviceContainer;
+        }
+
+        public IDependencyScope BeginScope()
+        {
+            return this as IDependencyScope;
+        }
+
+        public void Dispose()
+        {
+            _serviceContainer.DisposeIfDisposable();
+        }
+
+        public object GetService(Type serviceType) => _serviceContainer.GetService(serviceType);
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            var services = _serviceContainer.GetService(serviceType);
+            return services as IEnumerable<object> ?? Enumerable.Empty<object>();
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Models/EnvelopeModelBinder.cs.pp
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Models/EnvelopeModelBinder.cs.pp
@@ -1,0 +1,25 @@
+﻿using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
+using System;
+using System.Web.Http.Controllers;
+using System.Web.Http.ModelBinding;
+
+namespace $rootnamespace$
+{
+    public class EnvelopeModelBinder : IModelBinder
+    {
+        private readonly JsonNetSerializer _serializer;
+
+        public EnvelopeModelBinder()
+        {
+            _serializer = new JsonNetSerializer();
+        }
+
+        public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)
+        {
+            var json = actionContext.Request.Content.ReadAsStringAsync().Result;
+            bindingContext.Model = _serializer.Deserialize(json);
+            return bindingContext.Model != null;        
+        }
+    }
+}

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Properties/AssemblyInfo.cs
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Takenet.MessagingHub.Client.WebhookTemplate")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Takenet.MessagingHub.Client.WebhookTemplate")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("02ecd27b-7a12-4097-8dd4-cea83b0d064e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Readme.txt
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Readme.txt
@@ -1,0 +1,6 @@
+﻿Navigate to https://blip.ai to retrieve your application's Webhook key, and set it appSettings in Web.config.
+
+You just need to add a reference to you library project (using C# SDK) so it can run as a webhook template.
+
+See more information about how to build your application at https://blip.ai/portal/#/docs.
+  

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Takenet.MessagingHub.Client.Template.nuspec
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Takenet.MessagingHub.Client.Template.nuspec
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Takenet.MessagingHub.Client.WebhookTemplate</id>
+    <version>$version$</version>
+    <title>Messaging Hub Application Webhook Template</title>
+    <authors>Takenet</authors>
+    <owners>takenet</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Messaging Hub Application Webhook Template</description>
+    <summary>A template to expose Messaging Hub applications through webhook</summary>
+    <copyright>Copyright © 2016 Curupira S/A</copyright>
+    <tags>messagingHub blip</tags>
+  </metadata>
+  <dependencies>
+    <dependency id="Lime.Protocol" version="0.6.24" />
+    <dependency id="Microsoft.AspNet.WebApi" version="5.2.3" />
+    <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+    <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
+    <dependency id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" />
+    <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
+    <dependency id="Newtonsoft.Json" version="9.0.1" />
+  </dependencies>
+  <files>
+    <file src="App_Start\MessagingHubConfig.cs.pp" target="content\App_Start\MessagingHubConfig.cs.pp"/>
+    <file src="App_Start\WebApiConfig.cs.pp" target="content\App_Start\WebApiConfig.cs.pp"/>
+    <file src="Controllers\EnvelopeController.cs.pp" target="content\Controllers\EnvelopeController.cs.pp"/>
+    <file src="Models\EnvelopeModelBinder.cs.pp" target="content\Models\EnvelopeModelBinder.cs.pp"/>
+    <file src="EnvelopeBuffer.cs.pp" target="content\EnvelopeBuffer.cs.pp"/>
+    <file src="Global.asax.cs.pp" target="content\Global.asax.cs.pp"/>
+    <file src="Global.asax.pp" target="content\Global.asax.pp"/>
+    <file src="HttpMessagingHubConnection.cs.pp" target="content\HttpMessagingHubConnection.cs.pp"/>
+    <file src="HttpOnDemandClientChannel.cs.pp" target="content\HttpOnDemandClientChannel.cs.pp"/>
+    <file src="IEnvelopeBuffer.cs.pp" target="content\IEnvelopeBuffer.cs.pp"/>
+    <file src="MessagingHubClientResolver.cs.pp" target="content\MessagingHubClientResolver.cs.pp"/>
+    <file src="Readme.txt" target="" />
+  </files>
+</package>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Takenet.MessagingHub.Client.WebhookTemplate.csproj
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Takenet.MessagingHub.Client.WebhookTemplate.csproj
@@ -1,0 +1,137 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Takenet.MessagingHub.Client.WebhookTemplate</RootNamespace>
+    <AssemblyName>Takenet.MessagingHub.Client.WebhookTemplate</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax.cs.pp" />
+    <None Include="Global.asax.pp" />
+    <Content Include="Readme.txt" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App_Start\MessagingHubConfig.cs.pp" />
+    <None Include="App_Start\WebApiConfig.cs.pp" />
+    <None Include="Controllers\EnvelopeController.cs.pp" />
+    <None Include="Models\EnvelopeModelBinder.cs.pp" />
+    <None Include="EnvelopeBuffer.cs.pp" />
+    <None Include="HttpMessagingHubConnection.cs.pp" />
+    <None Include="HttpOnDemandClientChannel.cs.pp" />
+    <None Include="IEnvelopeBuffer.cs.pp" />
+    <None Include="MessagingHubClientResolver.cs.pp" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="Takenet.MessagingHub.Client.Template.nuspec">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>64564</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:64564/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.Debug.config
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.Release.config
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.config
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/Web.config
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="MessagingHub.BaseUrl" value="https://hmg.msging.net/"/>
+    <!--<add key="MessagingHub.Identifier" value="identifier"/>
+    <add key="MessagingHub.AccessKey" value="key"/>-->
+    <add key="MessagingHub.WebhookKey" value="dGFrZXFhbWluZWxsaTE2MDkwMjpHTlJzTzVGRzFyaDJPbEF0ek50TQ=="/>
+    <add key="MessagingHub.SendTimeout" value="15000"/>
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.6.1" />
+    <httpRuntime targetFramework="4.6.1" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/Takenet.MessagingHub.Client.WebhookTemplate/packages.config
+++ b/src/Takenet.MessagingHub.Client.WebhookTemplate/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Lime.Protocol" version="0.6.24" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>

--- a/src/Takenet.MessagingHub.Client.sln
+++ b/src/Takenet.MessagingHub.Client.sln
@@ -68,6 +68,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BingImageSearch", "Samples\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Takenet.MessagingHub.Client.WebHost", "Takenet.MessagingHub.Client.WebHost\Takenet.MessagingHub.Client.WebHost.csproj", "{5ED33BDE-A2BA-480B-B487-C5C896DA726E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Takenet.MessagingHub.Client.WebhookTemplate", "Takenet.MessagingHub.Client.WebhookTemplate\Takenet.MessagingHub.Client.WebhookTemplate.csproj", "{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,12 @@ Global
 		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Production|Any CPU.Build.0 = Release|Any CPU
 		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Production|Any CPU.ActiveCfg = Release|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Production|Any CPU.Build.0 = Release|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02ECD27B-7A12-4097-8DD4-CEA83B0D064E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Takenet.MessagingHub.Client.sln
+++ b/src/Takenet.MessagingHub.Client.sln
@@ -66,6 +66,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Navigation", "Samples\Navig
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BingImageSearch", "Samples\BingImageSearch\BingImageSearch.csproj", "{33049C01-E17A-4153-882E-19482E75BF11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Takenet.MessagingHub.Client.WebHost", "Takenet.MessagingHub.Client.WebHost\Takenet.MessagingHub.Client.WebHost.csproj", "{5ED33BDE-A2BA-480B-B487-C5C896DA726E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -175,6 +177,12 @@ Global
 		{33049C01-E17A-4153-882E-19482E75BF11}.Production|Any CPU.Build.0 = Release|Any CPU
 		{33049C01-E17A-4153-882E-19482E75BF11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33049C01-E17A-4153-882E-19482E75BF11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Production|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Production|Any CPU.Build.0 = Release|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED33BDE-A2BA-480B-B487-C5C896DA726E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Takenet.MessagingHub.Client/Host/Bootstrapper.cs
+++ b/src/Takenet.MessagingHub.Client/Host/Bootstrapper.cs
@@ -79,6 +79,44 @@ namespace Takenet.MessagingHub.Client.Host
             if (application.SessionCompression.HasValue) builder = builder.UsingCompression(application.SessionCompression.Value);
             if (application.Throughput != 0) builder = builder.WithThroughput(application.Throughput);
 
+            var localServiceProvider = BuildServiceProvider(application);
+
+            localServiceProvider.RegisterService(typeof(IServiceProvider), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(IServiceContainer), localServiceProvider);
+            localServiceProvider.RegisterService(typeof(MessagingHubClientBuilder), builder);
+            localServiceProvider.RegisterService(typeof(Application), application);
+            RegisterSettingsContainer(application, localServiceProvider);
+
+            var client = await BuildMessagingHubClientAsync(application, builder.Build, localServiceProvider);
+
+            await client.StartAsync().ConfigureAwait(false);
+
+            var stoppables = new IStoppable[2];
+            stoppables[0] = client;
+            var startable = await BuildStartupAsync(application, localServiceProvider);
+            if (startable != null)
+            {
+                stoppables[1] = startable as IStoppable;
+            }
+
+            return new StoppableWrapper(stoppables);
+        }
+
+        public static async Task<IStartable> BuildStartupAsync(Application application, IServiceContainer localServiceProvider)
+        {
+            if (application.StartupType == null) return null;
+
+            var startable = await CreateAsync<IStartable>(
+                application.StartupType,
+                localServiceProvider,
+                application.Settings)
+                .ConfigureAwait(false);
+            await startable.StartAsync().ConfigureAwait(false);
+            return startable;
+        }
+
+        public static IServiceContainer BuildServiceProvider(Application application)
+        {
             var localServiceProvider = new TypeServiceProvider();
             if (application.ServiceProviderType != null)
             {
@@ -104,32 +142,10 @@ namespace Takenet.MessagingHub.Client.Host
                 }
             }
 
-            localServiceProvider.RegisterService(typeof(IServiceProvider), localServiceProvider);
-            localServiceProvider.RegisterService(typeof(IServiceContainer), localServiceProvider);
-            localServiceProvider.RegisterService(typeof(MessagingHubClientBuilder), builder);
-            localServiceProvider.RegisterService(typeof(Application), application);
-            RegisterSettingsContainer(application, localServiceProvider);
-
-            var client = await BuildMessagingHubClientAsync(application, builder, localServiceProvider);
-
-            await client.StartAsync().ConfigureAwait(false);
-
-            var stoppables = new IStoppable[2];
-            stoppables[0] = client;
-            if (application.StartupType != null)
-            {
-                var startable = await CreateAsync<IStartable>(
-                    application.StartupType,
-                    localServiceProvider,
-                    application.Settings)
-                    .ConfigureAwait(false);
-                await startable.StartAsync().ConfigureAwait(false);
-                stoppables[1] = startable as IStoppable;
-            }
-            return new StoppableWrapper(stoppables);
+            return localServiceProvider;
         }
 
-        private static void RegisterSettingsContainer(SettingsContainer settingsContainer, IServiceContainer serviceContainer)
+        public static void RegisterSettingsContainer(SettingsContainer settingsContainer, IServiceContainer serviceContainer)
         {
             if (settingsContainer.SettingsType != null)
             {
@@ -144,9 +160,25 @@ namespace Takenet.MessagingHub.Client.Host
             }
         }
 
-        private static async Task<IMessagingHubClient> BuildMessagingHubClientAsync(
-            Application application, MessagingHubClientBuilder builder,
-            TypeServiceProvider typeServiceProvider)
+        public static async Task<IMessagingHubClient> BuildMessagingHubClientAsync(
+            Application application, Func<IMessagingHubClient> builder,
+            IServiceContainer serviceContainer)
+        {
+            RegisterSettingsTypes(application, serviceContainer);
+
+            var client = builder();
+            serviceContainer.RegisterService(typeof(IMessagingHubSender), client);
+            serviceContainer.RegisterService(typeof(IStateManager), StateManager.Instance);
+            serviceContainer.RegisterExtensions();
+
+            // Now creates the receivers instances
+            await AddMessageReceivers(application, serviceContainer, client);
+            await AddNotificationReceivers(application, serviceContainer, client);
+
+            return client;
+        }
+
+        public static void RegisterSettingsTypes(Application application, IServiceContainer serviceContainer)
         {
             var applicationReceivers =
                 (application.MessageReceivers ?? new ApplicationReceiver[0]).Union(
@@ -155,15 +187,71 @@ namespace Takenet.MessagingHub.Client.Host
             // First, register the receivers settings
             foreach (var applicationReceiver in applicationReceivers.Where(a => a.SettingsType != null))
             {
-                RegisterSettingsContainer(applicationReceiver, typeServiceProvider);
+                RegisterSettingsContainer(applicationReceiver, serviceContainer);
             }
+        }
 
-            var client = builder.Build();
-            typeServiceProvider.RegisterService(typeof(IMessagingHubSender), client);
-            typeServiceProvider.RegisterService(typeof(IStateManager), StateManager.Instance);
-            typeServiceProvider.RegisterExtensions();
+        private static async Task AddNotificationReceivers(Application application, IServiceContainer serviceContainer, IMessagingHubClient client)
+        {
+            if (application.NotificationReceivers != null && application.NotificationReceivers.Length > 0)
+            {
+                foreach (var applicationReceiver in application.NotificationReceivers)
+                {
+                    INotificationReceiver receiver;
+                    if (applicationReceiver.Response?.MediaType != null)
+                    {
+                        var content = applicationReceiver.Response.ToDocument();
+                        receiver =
+                            new LambdaNotificationReceiver(
+                                (notification, c) => client.SendMessageAsync(content, notification.From, c));
+                    }
+                    else
+                    {
+                        receiver = await CreateAsync<INotificationReceiver>(
+                            applicationReceiver.Type, serviceContainer, applicationReceiver.Settings)
+                            .ConfigureAwait(false);
+                    }
 
-            // Now creates the receivers instances
+                    Predicate<Notification> notificationPredicate = n => n != null;
+
+                    if (applicationReceiver.EventType != null)
+                    {
+                        var currentNotificationPredicate = notificationPredicate;
+                        notificationPredicate = n => currentNotificationPredicate(n) && n.Event.Equals(applicationReceiver.EventType);
+                    }
+
+                    if (applicationReceiver.Sender != null)
+                    {
+                        var currentNotificationPredicate = notificationPredicate;
+                        var senderRegex = new Regex(applicationReceiver.Sender, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                        notificationPredicate = n => currentNotificationPredicate(n) && senderRegex.IsMatch(n.From.ToString());
+                    }
+
+                    if (applicationReceiver.Destination != null)
+                    {
+                        var currentNotificationPredicate = notificationPredicate;
+                        var destinationRegex = new Regex(applicationReceiver.Destination, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                        notificationPredicate = n => currentNotificationPredicate(n) && destinationRegex.IsMatch(n.To.ToString());
+                    }
+
+                    if (applicationReceiver.State != null)
+                    {
+                        var currentNotificationPredicate = notificationPredicate;
+                        notificationPredicate = n => currentNotificationPredicate(n) && StateManager.Instance.GetState(n.From.ToIdentity()).Equals(applicationReceiver.State, StringComparison.OrdinalIgnoreCase);
+                    }
+
+                    if (applicationReceiver.OutState != null)
+                    {
+                        receiver = new SetStateNotificationReceiver(receiver, applicationReceiver.OutState);
+                    }
+
+                    client.AddNotificationReceiver(receiver, notificationPredicate, applicationReceiver.Priority);
+                }
+            }
+        }
+
+        public static async Task AddMessageReceivers(Application application, IServiceContainer serviceContainer, IMessagingHubClient client)
+        {
             if (application.MessageReceivers != null && application.MessageReceivers.Length > 0)
             {
                 foreach (var applicationReceiver in application.MessageReceivers)
@@ -179,7 +267,7 @@ namespace Takenet.MessagingHub.Client.Host
                     else
                     {
                         receiver = await CreateAsync<IMessageReceiver>(
-                            applicationReceiver.Type, typeServiceProvider, applicationReceiver.Settings)
+                            applicationReceiver.Type, serviceContainer, applicationReceiver.Settings)
                             .ConfigureAwait(false);
                     }
 
@@ -227,66 +315,7 @@ namespace Takenet.MessagingHub.Client.Host
                     client.AddMessageReceiver(receiver, messagePredicate, applicationReceiver.Priority);
                 }
             }
-
-            if (application.NotificationReceivers != null && application.NotificationReceivers.Length > 0)
-            {
-                foreach (var applicationReceiver in application.NotificationReceivers)
-                {
-                    INotificationReceiver receiver;
-                    if (applicationReceiver.Response?.MediaType != null)
-                    {
-                        var content = applicationReceiver.Response.ToDocument();
-                        receiver =
-                            new LambdaNotificationReceiver(
-                                (notification, c) => client.SendMessageAsync(content, notification.From, c));
-                    }
-                    else
-                    {
-                        receiver = await CreateAsync<INotificationReceiver>(
-                            applicationReceiver.Type, typeServiceProvider, applicationReceiver.Settings)
-                            .ConfigureAwait(false);
-                    }
-
-                    Predicate<Notification> notificationPredicate = n => n != null;
-
-                    if (applicationReceiver.EventType != null)
-                    {
-                        var currentNotificationPredicate = notificationPredicate;
-                        notificationPredicate = n => currentNotificationPredicate(n) && n.Event.Equals(applicationReceiver.EventType);
-                    }
-
-                    if (applicationReceiver.Sender != null)
-                    {
-                        var currentNotificationPredicate = notificationPredicate;
-                        var senderRegex = new Regex(applicationReceiver.Sender, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-                        notificationPredicate = n => currentNotificationPredicate(n) && senderRegex.IsMatch(n.From.ToString());
-                    }
-
-                    if (applicationReceiver.Destination != null)
-                    {
-                        var currentNotificationPredicate = notificationPredicate;
-                        var destinationRegex = new Regex(applicationReceiver.Destination, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-                        notificationPredicate = n => currentNotificationPredicate(n) && destinationRegex.IsMatch(n.To.ToString());
-                    }
-
-                    if (applicationReceiver.State != null)
-                    {
-                        var currentNotificationPredicate = notificationPredicate;
-                        notificationPredicate = n => currentNotificationPredicate(n) && StateManager.Instance.GetState(n.From.ToIdentity()).Equals(applicationReceiver.State, StringComparison.OrdinalIgnoreCase);
-                    }
-
-                    if (applicationReceiver.OutState != null)
-                    {
-                        receiver = new SetStateNotificationReceiver(receiver, applicationReceiver.OutState);
-                    }
-
-                    client.AddNotificationReceiver(receiver, notificationPredicate, applicationReceiver.Priority);
-                }
-            }
-
-            return client;
         }
-
 
         public static Task<T> CreateAsync<T>(string typeName, IServiceProvider serviceProvider, IDictionary<string, object> settings) where T : class
         {

--- a/src/Takenet.MessagingHub.Client/Host/IServiceContainer.cs
+++ b/src/Takenet.MessagingHub.Client/Host/IServiceContainer.cs
@@ -18,5 +18,7 @@ namespace Takenet.MessagingHub.Client.Host
         /// <param name="serviceType">Type of the service.</param>
         /// <param name="instance">The instance.</param>
         void RegisterService(Type serviceType, object instance);
+
+        void RegisterService(Type serviceType, Func<object> instanceFactory);
     }
 }

--- a/src/Takenet.MessagingHub.Client/Host/TypeServiceProvider.cs
+++ b/src/Takenet.MessagingHub.Client/Host/TypeServiceProvider.cs
@@ -28,8 +28,16 @@ namespace Takenet.MessagingHub.Client.Host
         {
             if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
             object result;
-            return TypeDictionary.TryGetValue(serviceType, out result) ?
+            var service = TypeDictionary.TryGetValue(serviceType, out result) ?
                 result : SecondaryServiceProvider?.GetService(serviceType);
+
+            var factory = service as Func<object>;
+            if (factory != null)
+            {
+                return factory();
+            }
+
+            return service;
         }
 
         /// <summary>
@@ -47,9 +55,18 @@ namespace Takenet.MessagingHub.Client.Host
             (SecondaryServiceProvider as IServiceContainer)?.RegisterService(serviceType, instance);
         }
 
+        public void RegisterService(Type serviceType, Func<object> instanceFactory)
+        {
+            if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
+            if (instanceFactory == null) throw new ArgumentNullException(nameof(instanceFactory));
+            TypeDictionary.Add(serviceType, instanceFactory);
+            (SecondaryServiceProvider as IServiceContainer)?.RegisterService(serviceType, instanceFactory);
+        }
+
         public void RegisterExtensions()
         {
             throw new NotImplementedException();
         }
+
     } 
 }

--- a/src/Takenet.MessagingHub.Client/Host/TypeServiceProvider.cs
+++ b/src/Takenet.MessagingHub.Client/Host/TypeServiceProvider.cs
@@ -16,7 +16,7 @@ namespace Takenet.MessagingHub.Client.Host
             TypeDictionary = new Dictionary<Type, object>();
         }
 
-        public IServiceProvider SecondaryServiceProvider { get; internal set; }
+        public IServiceProvider SecondaryServiceProvider { get; set; }
 
         /// <summary>
         /// Gets the service.
@@ -45,6 +45,11 @@ namespace Takenet.MessagingHub.Client.Host
             if (instance == null) throw new ArgumentNullException(nameof(instance));            
             TypeDictionary.Add(serviceType, instance);
             (SecondaryServiceProvider as IServiceContainer)?.RegisterService(serviceType, instance);
+        }
+
+        public void RegisterExtensions()
+        {
+            throw new NotImplementedException();
         }
     } 
 }

--- a/src/Takenet.MessagingHub.Client/StateManager.cs
+++ b/src/Takenet.MessagingHub.Client/StateManager.cs
@@ -12,7 +12,7 @@ namespace Takenet.MessagingHub.Client
     /// <summary>
     /// Provides the management of states for filtering message and notification receivers registered in the application.
     /// </summary>
-    internal sealed class StateManager : IStateManager
+    public sealed class StateManager : IStateManager
     {
         public const string DEFAULT_STATE = "default";
         


### PR DESCRIPTION
WebhookTemplate is a WebApi-based template that exposes over HTTP an existing library project using current Template package. All it needs to be used is to create an Web Api project, install the WebhookTemplate and reference your existing library project with the standard host.

The main change is an IOnDemandClientChannel implementation using HTTP instead of TCP, injected into the client' ServiceContainer.
The webhook key must be set on appSettings inside Web.config.