### PR TITLE
Introduce IMessageReceiverFactory

### DIFF
--- a/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
+++ b/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
@@ -207,7 +207,7 @@ namespace Takenet.MessagingHub.Client.Host.Test
         }
 
         [Test]
-        public async Task Create_With_MessageReceiverType_Should_Return_Instance()
+        public async Task Create_With_MessageReceiverType_Should_NotReturn_Instance()
         {
             // Arrange
             var application = new Application()
@@ -239,7 +239,7 @@ namespace Takenet.MessagingHub.Client.Host.Test
 
             // Assert
             actual.ShouldNotBeNull();
-            TestMessageReceiver.InstanceCount.ShouldBe(3);
+            TestMessageReceiver.InstanceCount.ShouldBe(0);
         }
 
         [Test]

--- a/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
+++ b/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
@@ -207,7 +207,7 @@ namespace Takenet.MessagingHub.Client.Host.Test
         }
 
         [Test]
-        public async Task Create_With_MessageReceiverType_Should_NotReturn_Instance()
+        public async Task Create_With_MessageReceiverType_Should_Return_Instance()
         {
             // Arrange
             var application = new Application()
@@ -239,7 +239,44 @@ namespace Takenet.MessagingHub.Client.Host.Test
 
             // Assert
             actual.ShouldNotBeNull();
-            TestMessageReceiver.InstanceCount.ShouldBe(0);
+            TestMessageReceiver.InstanceCount.ShouldBe(3);
+        }
+
+        [Test]
+        public async Task Create_With_MessageReceiverTypeAndScopedLifetime_Should_NotReturn_Instance()
+        {
+            // Arrange
+            var application = new Application()
+            {
+                Identifier = "testlogin",
+                AccessKey = "12345".ToBase64(),
+                MessageReceivers = new[]
+                {
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).Name,
+                        MediaType = "text/plain",
+                        Lifetime = "scoped"
+                    },
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).Name,
+                        MediaType = "application/json"
+                    },
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).AssemblyQualifiedName
+                    }
+                },
+                HostName = Server.ListenerUri.Host
+            };
+
+            // Act
+            var actual = await Bootstrapper.StartAsync(application);
+
+            // Assert
+            actual.ShouldNotBeNull();
+            TestMessageReceiver.InstanceCount.ShouldBe(2);
         }
 
         [Test]

--- a/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
+++ b/src/Takenet.MessagingHub.Client.Host.Test/BootstrapperTests.cs
@@ -256,7 +256,7 @@ namespace Takenet.MessagingHub.Client.Host.Test
                     {
                         Type = typeof(TestMessageReceiver).Name,
                         MediaType = "text/plain",
-                        Lifetime = "scoped"
+                        Lifetime = ReceiverLifetime.Scoped
                     },
                     new MessageApplicationReceiver()
                     {

--- a/src/Takenet.MessagingHub.Client/Host/Application.cs
+++ b/src/Takenet.MessagingHub.Client/Host/Application.cs
@@ -92,6 +92,14 @@ namespace Takenet.MessagingHub.Client.Host
         public int SendTimeout { get; set; }
 
         /// <summary>
+        /// Gets or sets the default lifetime for MessageReceivers.
+        /// </summary>
+        /// <value>
+        /// The lifetime.
+        /// </value>
+        public ReceiverLifetime DefaultMessageReceiverLifetime { get; set; }
+
+        /// <summary>
         /// Gets or sets the messages receivers.
         /// </summary>
         /// <value>

--- a/src/Takenet.MessagingHub.Client/Host/MessageApplicationReceiver.cs
+++ b/src/Takenet.MessagingHub.Client/Host/MessageApplicationReceiver.cs
@@ -24,6 +24,6 @@ namespace Takenet.MessagingHub.Client.Host
         /// - singleton (default)
         /// - scoped (an instance per message request)
         /// </summary>
-        public string Lifetime { get; set; }
+        public ReceiverLifetime? Lifetime { get; set; }
     }
 }

--- a/src/Takenet.MessagingHub.Client/Host/MessageApplicationReceiver.cs
+++ b/src/Takenet.MessagingHub.Client/Host/MessageApplicationReceiver.cs
@@ -17,5 +17,13 @@ namespace Takenet.MessagingHub.Client.Host
         /// The text regex.
         /// </value>
         public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lifetime of the receiver instance.
+        /// Options:
+        /// - singleton (default)
+        /// - scoped (an instance per message request)
+        /// </summary>
+        public string Lifetime { get; set; }
     }
 }

--- a/src/Takenet.MessagingHub.Client/Host/ReceiverLifetime.cs
+++ b/src/Takenet.MessagingHub.Client/Host/ReceiverLifetime.cs
@@ -1,0 +1,8 @@
+﻿namespace Takenet.MessagingHub.Client.Host
+{
+    public enum ReceiverLifetime
+    {
+        Singleton,
+        Scoped
+    }
+}

--- a/src/Takenet.MessagingHub.Client/Takenet.MessagingHub.Client.csproj
+++ b/src/Takenet.MessagingHub.Client/Takenet.MessagingHub.Client.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Host\ITypeResolver.cs" />
     <Compile Include="Host\MessageApplicationReceiver.cs" />
     <Compile Include="Host\NotificationApplicationReceiver.cs" />
+    <Compile Include="Host\ReceiverLifetime.cs" />
     <Compile Include="Host\ServiceProviderExtensions.cs" />
     <Compile Include="Host\SettingsContainer.cs" />
     <Compile Include="Host\TypeResolver.cs" />


### PR DESCRIPTION
The current implementation creates all MessageReceivers instances when starting.

I think could be very useful to allow clients to override this behavior. 
For instance, in order to produce instances scoped by message for instance: imagine a context provider which can offer the message, the contact for this message and other properties related to current user.

To allow this scenario I have added IMessageReceiverFactory, which is used to get the receiver before processing each request. If no implementation could be found by the IServiceProvider, a default implementing the current logic will be used.

Some tests are intentionally failing to demonstrate the impacts of this change. If this request manages to be accepted they should probably be deleted.